### PR TITLE
feat: parse dependency versions

### DIFF
--- a/package.go
+++ b/package.go
@@ -70,10 +70,13 @@ func (c *Package) dependencies(nevrsTagID, flagsTagID, namesTagID, versionsTagID
 	vers := c.Header.GetTag(versionsTagID).StringSlice()
 	deps := make([]Dependency, len(names))
 	for i := 0; i < len(names); i++ {
+		epoch, ver, rel := parseVersion(vers[i])
 		deps[i] = &dependency{
 			flags:   int(flgs[i]),
 			name:    names[i],
-			version: vers[i],
+			epoch:   epoch,
+			version: ver,
+			release: rel,
 		}
 	}
 	return deps

--- a/util.go
+++ b/util.go
@@ -1,6 +1,9 @@
 package rpm
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // TimeFormat is the time format used by the rpm ecosystem. The time being
 // formatted must be in UTC for Format to generate the correct format.
@@ -8,4 +11,27 @@ const TimeFormat = "Mon Jan _2 15:04:05 2006"
 
 func errorf(format string, a ...interface{}) error {
 	return fmt.Errorf("rpm: "+format, a...)
+}
+
+func parseVersion(v string) (epoch int, version, release string) {
+	if i := strings.IndexByte(v, ':'); i >= 0 {
+		epoch, v = parseInt(v[:i]), v[i+1:]
+	}
+
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		return epoch, v[:i], v[i+1:]
+	}
+
+	return epoch, v, ""
+}
+
+func parseInt(s string) int {
+	var n int
+	for _, dec := range s {
+		if dec < '0' || dec > '9' {
+			return 0
+		}
+		n = n*10 + (int(dec) - '0')
+	}
+	return n
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,32 @@
+package rpm
+
+import "testing"
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		in      string
+		epoch   int
+		version string
+		release string
+	}{
+		{"", 0, "", ""},
+		{"1.0", 0, "1.0", ""},
+		{"1:1.0", 1, "1.0", ""},
+		{"1:1.0-test", 1, "1.0", "test"},
+		{"1.0-test", 0, "1.0", "test"},
+		{":1.0-", 0, "1.0", ""}, // Ensure malformed version doesn't panic.
+	}
+
+	for _, test := range tests {
+		epoch, ver, rel := parseVersion(test.in)
+		if epoch != test.epoch {
+			t.Errorf("Expected epoch %d for %q; got %d", test.epoch, test.in, epoch)
+		}
+		if ver != test.version {
+			t.Errorf("Expected version %s for %q; got %s", test.version, test.in, ver)
+		}
+		if rel != test.release {
+			t.Errorf("Expected release %s for %q; got %s", test.release, test.in, rel)
+		}
+	}
+}


### PR DESCRIPTION
Parse version string in dependencies into epoch, version & release.

This is technically a breaking change but I checked all the libraries importing this package on https://pkg.go.dev/github.com/cavaliergopher/rpm?tab=importedby and not one of them uses this so seems like a fairly safe change.