### PR TITLE
feat: header range

### DIFF
--- a/header.go
+++ b/header.go
@@ -12,6 +12,7 @@ const r_MaxHeaderSize = 33554432
 type Header struct {
 	Version int
 	Tags    map[int]*Tag
+	Size    int
 }
 
 // GetTag returns the tag with the given identifier.
@@ -173,15 +174,18 @@ func readHeader(r io.Reader, pad bool) (*Header, error) {
 	}
 
 	// pad to next header
-	padding := int64(8-(hdrBytes.Size()%8)) % 8
-	if pad && padding != 0 {
-		if _, err := io.CopyN(ioutil.Discard, r, padding); err != nil {
-			return nil, err
+	var padding int64
+	if pad {
+		if padding = int64(8-(hdrBytes.Size()%8)) % 8; padding != 0 {
+			if _, err := io.CopyN(ioutil.Discard, r, padding); err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	return &Header{
 		Version: hdrBytes.Version(),
 		Tags:    tags,
+		Size:    16 + hdrBytes.Size() + hdrBytes.IndexCount()*16 + int(padding),
 	}, nil
 }

--- a/package.go
+++ b/package.go
@@ -108,6 +108,13 @@ func (c *Package) Epoch() int {
 	return int(c.Header.GetTag(1003).Int64())
 }
 
+// HeaderRange returns the byte offsets of the RPM header.
+func (c *Package) HeaderRange() (start, end int) {
+	start = 96 + c.Signature.Size
+	end = start + c.Header.Size
+	return start, end
+}
+
 func (c *Package) Requires() []Dependency {
 	return c.dependencies(5041, 1048, 1049, 1050)
 }


### PR DESCRIPTION
When using this library to generate YUM repos from RPM files, the `primary.xml` file needs the header range in `package/format/rpm:header-range`, so I added a method to `Package` to get this.