### PR TITLE
Fix md5 checksum for big RPMs

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -144,9 +144,12 @@ func MD5Check(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	payloadSize := sigheader.GetTag(1000).Int64() // RPMSIGTAG_SIZE
+	payloadSize := sigheader.GetTag(270).Int64() // RPMSIGTAG_LONGSIGSIZE
 	if payloadSize == 0 {
-		return errorf("tag not found: RPMSIGTAG_SIZE")
+		payloadSize = sigheader.GetTag(1000).Int64() // RPMSIGTAG_SIGSIZE
+		if payloadSize == 0 {
+			return fmt.Errorf("tag not found: RPMSIGTAG_SIZE")
+		}
 	}
 	expect := sigheader.GetTag(1004).Bytes() // RPMSIGTAG_MD5
 	if expect == nil {


### PR DESCRIPTION
Big RPMs don't set size in `RPMSIGTAG_SIGSIZE` but use `RPMSIGTAG_LONGSIGSIZE` instead